### PR TITLE
Added image-with-text section

### DIFF
--- a/src/layout/theme.liquid
+++ b/src/layout/theme.liquid
@@ -53,12 +53,12 @@
 </head>
 
 <body id="{{ page_title | handle }}" class="template-{{ template.name | handle }}">
-
+  
   <a class="in-page-link visually-hidden skip-link" href="#MainContent">{{ 'general.accessibility.skip_to_content' | t }}</a>
 
   {% section 'header' %}
 
-  <main role="main" id="MainContent">
+  <main role="main" id="MainContent" class="body-wrapper">
     {{ content_for_layout }}
   </main>
 

--- a/src/sections/header.liquid
+++ b/src/sections/header.liquid
@@ -11,115 +11,117 @@
   - Home page only: only shows on the home page
 {%- endcomment -%}
 <section class="header" data-section-id="{{ section.id }}" data-section-type="header">
-  <nav role="navigation" class="header__left">
-    <ul>
-      {% for link in linklists[section.settings.left_menu].links %}
-        {% if link.links != blank %}
-          <li>
-            <a href="{{ link.url }}">
-              {{ link.title }}
-              {% include 'icon-arrow-down' %}
-            </a>
-            <ul>
-              {% for childlink in link.links %}
-                <li>
-                  <a href="{{ childlink.url }}">
-                    {{ childlink.title }}
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-          </li>
-        {% else %}
-          <li>
-            <a href="{{ link.url }}">
-              {{ link.title }}
-            </a>
-          </li>
-        {% endif %}
-      {% endfor %}
-    </ul>
-  </nav>
+  <div class="body-wrapper f jcb">
+    <nav role="navigation" class="header__left">
+      <ul>
+        {% for link in linklists[section.settings.left_menu].links %}
+          {% if link.links != blank %}
+            <li>
+              <a href="{{ link.url }}">
+                {{ link.title }}
+                {% include 'icon-arrow-down' %}
+              </a>
+              <ul>
+                {% for childlink in link.links %}
+                  <li>
+                    <a href="{{ childlink.url }}">
+                      {{ childlink.title }}
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </li>
+          {% else %}
+            <li>
+              <a href="{{ link.url }}">
+                {{ link.title }}
+              </a>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </nav>
 
-  <header role="banner" class="header__center">
-    {% if template.name == 'index' %}
-      <h1>
-    {% else %}
-      <div class="h1">
-    {% endif %}
-        <a href="/" class="logo-image">
-          <img src="{{ 'logo.svg' | asset_url }}" />
-        </a>
-    {% if template.name == 'index' %}
-      </h1>
-    {% else %}
-      </div>
-    {% endif %}
-
-  </header>
-
-  <nav class="header__right" role="navigation">
-    <ul>
-      {% if shop.customer_accounts_enabled %}
-        {% if customer %}
-          <li>
-            {% if customer.first_name != blank %}
-              {% capture first_name %}<a href="/account">{{ customer.first_name }}</a>{% endcapture %}
-              {{ 'layout.customer.logged_in_as_html' | t: first_name: first_name }}
-            {% else %}
-              <a href="/account">{{ 'layout.customer.account' | t }}</a>
-            {% endif %}
-          </li>
-          <li>
-            {{ 'layout.customer.log_out' | t | customer_logout_link }}
-          </li>
-        {% else %}
-          <li>
-            {{ 'layout.customer.log_in' | t | customer_login_link }}
-          </li>
-          <li>
-            {{ 'layout.customer.create_account' | t | customer_register_link }}
-          </li>
-        {% endif %}
+    <header role="banner" class="header__center abs-c">
+      {% if template.name == 'index' %}
+        <h1>
+      {% else %}
+        <div class="h1">
       {% endif %}
-      <li>
-        {% include 'search-form' %}
-      </li>
-      {% for link in linklists[section.settings.right_menu].links %}
-        {% if link.links != blank %}
-          <li>
-            <a href="{{ link.url }}">
-              {{ link.title }}
-              {% include 'icon-arrow-down' %}
-            </a>
-            <ul>
-              {% for childlink in link.links %}
-                <li>
-                  <a href="{{ childlink.url }}">
-                    {{ childlink.title }}
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-          </li>
-        {% else %}
-          <li>
-            <a href="{{ link.url }}">
-              {{ link.title }}
-            </a>
-          </li>
+          <a href="/" class="logo-image">
+            <img src="{{ 'logo.svg' | asset_url }}" />
+          </a>
+      {% if template.name == 'index' %}
+        </h1>
+      {% else %}
+        </div>
+      {% endif %}
+
+    </header>
+
+    <nav class="header__right" role="navigation">
+      <ul>
+        {% if shop.customer_accounts_enabled %}
+          {% if customer %}
+            <li>
+              {% if customer.first_name != blank %}
+                {% capture first_name %}<a href="/account">{{ customer.first_name }}</a>{% endcapture %}
+                {{ 'layout.customer.logged_in_as_html' | t: first_name: first_name }}
+              {% else %}
+                <a href="/account">{{ 'layout.customer.account' | t }}</a>
+              {% endif %}
+            </li>
+            <li>
+              {{ 'layout.customer.log_out' | t | customer_logout_link }}
+            </li>
+          {% else %}
+            <li>
+              {{ 'layout.customer.log_in' | t | customer_login_link }}
+            </li>
+            <li>
+              {{ 'layout.customer.create_account' | t | customer_register_link }}
+            </li>
+          {% endif %}
         {% endif %}
-      {% endfor %}
+        <li>
+          {% include 'search-form' %}
+        </li>
+        {% for link in linklists[section.settings.right_menu].links %}
+          {% if link.links != blank %}
+            <li>
+              <a href="{{ link.url }}">
+                {{ link.title }}
+                {% include 'icon-arrow-down' %}
+              </a>
+              <ul>
+                {% for childlink in link.links %}
+                  <li>
+                    <a href="{{ childlink.url }}">
+                      {{ childlink.title }}
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </li>
+          {% else %}
+            <li>
+              <a href="{{ link.url }}">
+                {{ link.title }}
+              </a>
+            </li>
+          {% endif %}
+        {% endfor %}
 
-      <li>
-        <a href="/cart" class="header__cart" >
-          {{ 'layout.cart.title' | t }}
-          [{{ cart.item_count }}]
-        </a>
-      </li>
-    </ul>
+        <li>
+          <a href="/cart" class="header__cart" >
+            {{ 'layout.cart.title' | t }}
+            [{{ cart.item_count }}]
+          </a>
+        </li>
+      </ul>
 
-  </nav>
+    </nav>
+  </div>
 </section>
 
 {% schema %}

--- a/src/sections/image-with-text.liquid
+++ b/src/sections/image-with-text.liquid
@@ -1,58 +1,39 @@
-{%- comment -%}
-  This is a required section for the Shopify Theme Store.
-  It is available when you add the "Image with text" section in the theme editor.
+{% assign layout = section.settings.layout %}
 
-  Theme Store required settings
-  - Image
-  - Heading: title of the block
-  - Text: description of the block
-
-  Theme Store optional settings
-  - Button label: label associated with the button
-  - Button link: link of the button
-{%- endcomment -%}
-
-<section class="image-with-text">
-  {% capture image_layout %}
-    <div class="image-with-text__image">
-      {% if section.settings.image != blank %}
-        {% include 'responsive-image' with
-          image: section.settings.image,
-          max_width: 545,
-          max_height: 545
-        %}
-      {% else %}
-        {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
-      {% endif %}
-    </div>
-  {% endcapture %}
-
-  {% if section.settings.layout == 'left' %}
-    {{ image_layout }}
-  {% endif %}
-
-  <div class="image-with-text__text">
-    {% if section.settings.title != blank %}
-      <h2>{{ section.settings.title | escape }}</h2>
-    {% endif %}
-    {% if section.settings.text != blank %}
-      <div>{{ section.settings.text }}</div>
-    {% endif %}
-    {% if section.settings.button_label != blank and section.settings.button_link != blank %}
-      <a href="{{ section.settings.button_link }}">
-        {{ section.settings.button_label | escape }}
-      </a>
+<section class="image-with-text full-height jcb fdc-m {% if layout == 'left' %} fdr {% elsif layout == 'right' %} fdr-rev {% endif %}">
+  <div class="image-with-text__image half-width {% if layout == 'left' %} mr-d {% elsif layout == 'right' %} ml-d {% endif %}">
+    {% if section.settings.image != blank %}
+      <img src="{{ section.settings.image | img_url: 'master' }}"/>
+      {% comment %} {% include 'responsive-image' with
+        image: section.settings.image,
+        max_width: 720,
+        max_height: 828,
+      %} {% endcomment %}
+    {% else %}
+      {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
     {% endif %}
   </div>
-
-  {% if section.settings.layout == 'right' %}
-    {{ image_layout }}
-  {% endif %}
+  <div class="image-with-text__text fdc jcb half-width">
+    {% if section.settings.heading != blank %}
+      <h2 class="h2">{{ section.settings.heading | escape }}</h2>
+    {% endif %}
+    <div class="image-with-text__p">
+      {% if section.settings.text != blank %}
+        <div>{{ section.settings.text }}</div>
+      {% endif %}
+      {% if section.settings.button_label != blank and section.settings.button_link != blank %}
+        <a href="{{ section.settings.button_link }}" class="button-inline">
+          {{ section.settings.button_label | escape }}
+        </a>
+      {% endif %}
+    </div>
+  </div>
 </section>
 
 {% schema %}
   {
     "name": "Image with text",
+    "class": "index-section",
     "settings": [
       {
         "type": "image_picker",
@@ -77,7 +58,7 @@
       },
       {
         "type": "text",
-        "id": "title",
+        "id": "heading",
         "label": "Heading",
         "default": "Image with text"
       },

--- a/src/styles/global/_layout.scss
+++ b/src/styles/global/_layout.scss
@@ -22,9 +22,19 @@ a {
   }
 }
 
+.body-wrapper {
+  max-width: 1294px;
+  margin: 0 auto;
+  padding: 0 $padding-desktop;
+
+  @include media-query($small) {
+    padding: 0 $padding-mobile;
+  }
+}
+
 section,
 .section {
-  padding: $padding-desktop;
+  padding: $padding-desktop 0;
 }
 
 .button {
@@ -36,10 +46,16 @@ section,
   text-transform: uppercase;
   text-align: center;
   padding: calc(1rem / 2);
+  margin-top: 24px;
 }
 
 .button-white {
   @extend .button;
   color: $white;
   border: 1px solid $white;
+}
+
+.button-inline {
+  @extend .button;
+  width: fit-content;
 }

--- a/src/styles/global/_typography.scss
+++ b/src/styles/global/_typography.scss
@@ -1,3 +1,12 @@
+/*============= Reset ================*/
+
+p {
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+}
+
 /*============= Helpers ================*/
 
 .tc-white {
@@ -13,13 +22,18 @@
 
 .h1, .h2, .h3, .h4 {
   font-weight: 400;
+  text-transform: uppercase;
+  line-height: 1.5;
 }
 
 .h1 {
-  text-transform: uppercase;
-  line-height: 1.5;
   font-size: 48px;
   @include media-query($small) {
     font-size: 24px;
   }
+}
+
+.h2 {
+  font-size: 1rem;
+  margin-bottom: 24px;
 }

--- a/src/styles/modules/header.scss
+++ b/src/styles/modules/header.scss
@@ -5,9 +5,9 @@ $header-desktop-spacing: 64px;
   top: 0;
   text-transform: uppercase;
   border-bottom: 1px solid $black;
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  grid-template-rows: auto;
+  // display: grid;
+  // grid-template-columns: 1fr auto 1fr;
+  // grid-template-rows: auto;
 
   h1 {
     margin: 0;
@@ -51,6 +51,6 @@ $header-desktop-spacing: 64px;
   }
 
   @include media-query($medium-up) {
-    padding: 20px $padding-desktop;
+    padding: 20px 0;
   }
 }

--- a/src/styles/modules/hero.scss
+++ b/src/styles/modules/hero.scss
@@ -10,7 +10,7 @@
   max-width: 500px;
 }
 
-.button {
+.hero .button {
   width: 72px;
   margin-top: 32px;
 }

--- a/src/styles/modules/image-text.scss
+++ b/src/styles/modules/image-text.scss
@@ -1,0 +1,27 @@
+.image-with-text {
+  @include media-query($small) {
+    height: fit-content;
+  }
+}
+
+.image-with-text__image {
+  background-color: $gray;
+  max-height: 100%;
+  @include media-query($small) {
+    height: 240px;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}t
+
+.image-with-text__text {
+  max-width: 512px;
+
+  @include media-query($small) {
+    padding-top: $padding-desktop;
+  }
+}

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -24,6 +24,7 @@
 // *************************************
 @import './modules/header';
 @import './modules/hero';
+@import './modules/image-text.scss';
 
 // *************************************
 // ***** Components

--- a/src/styles/util/_helpers.scss
+++ b/src/styles/util/_helpers.scss
@@ -29,18 +29,60 @@
   flex-direction: row;
 }
 
+.fdr-rev {
+  display: flex;
+  flex-direction: row-reverse;
+}
+
 .fdc {
   display: flex;
   flex-direction: column;
 }
 
+.fdc-m {
+  @include media-query($small) {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
 
 /*============== Layout ================*/
 
+.abs-c {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
 .full-height {
   height: 100vh;
+
+  @include media-query($medium) {
+    height: 50vh;
+  }
+
   @include media-query($small) {
     height: 378px;
+  }
+}
+
+.half-width {
+  width: 50%;
+  @include media-query($small) {
+    width: 100%;
+  }
+}
+
+.mr-d {
+  @include media-query($medium-up) {
+    margin-right: $padding-desktop;
+  }
+}
+
+.ml-d {
+  @include media-query($medium-up) {
+    margin-left: $padding-desktop;
   }
 }
 

--- a/src/styles/util/_variables.scss
+++ b/src/styles/util/_variables.scss
@@ -1,5 +1,6 @@
 // Spacing
 $padding-desktop: 36px;
+$padding-mobile: 16px;
 
 // Colors
 $black: #000;


### PR DESCRIPTION
### Image With Text Section

- Made changes to the default `image-with-text` template, as the schema was exactly what we needed.
- Added content and responsive styles.
- Added `.h2` typography styles, and also a couple of styles to reset the weird browser margins on paragraphs.
- Added a couple of helper classes that aren't covered by svbstrate, but could be useful for other sections of the site, eg `fdc-m`, which will change flex row layouts to column layouts on mobile.
- I tried to wrap my head around the `responsive-image` snippet but I'm not completely understanding how it works, so I've just used the regular `img` tag for now and styled it in `image-text.scss`

### Global Layout

- I noticed that the sections were looking a bit too wide when your screen gets past 1440px – the images were looking absolutely huge and unbalanced against the text.
- To keep things looking as close to the design file as possible, I've wrapped the body and header content in a `body-wrapper` div. You can find the styles for this in `_layout.scss`, but basically it just constrains the content to a max width of 1294px.
- I had to change some of the header styles to get this to work, so feel free to get rid of this idea if it's not to your liking haha. Personally, I think it'll really help tighten the layout up and keep the padding consistent. The only place I can see it might cause some issues is the new arrivals slideshow on the homepage, but I think we can work around this.