### PR TITLE
Style adjustments

### DIFF
--- a/src/sections/header.liquid
+++ b/src/sections/header.liquid
@@ -10,8 +10,8 @@
   Theme Store optional settings
   - Home page only: only shows on the home page
 {%- endcomment -%}
-<section class="header" data-section-id="{{ section.id }}" data-section-type="header">
-  <div class="body-wrapper f jcb">
+<section class="header uppercase" data-section-id="{{ section.id }}" data-section-type="header">
+  <div class="body-wrapper header__inner y">
     <nav role="navigation" class="header__left">
       <ul>
         {% for link in linklists[section.settings.left_menu].links %}
@@ -42,7 +42,7 @@
       </ul>
     </nav>
 
-    <header role="banner" class="header__center abs-c">
+    <header role="banner" class="header__center">
       {% if template.name == 'index' %}
         <h1>
       {% else %}
@@ -127,6 +127,7 @@
 {% schema %}
   {
     "name": "Header",
+    "class": "header-wrapper z10",
     "settings": [
       {
         "type": "header",

--- a/src/sections/hero.liquid
+++ b/src/sections/hero.liquid
@@ -2,14 +2,11 @@
 {% assign img_url = settings.background_image | img_url: 'master' %}
 
 <section class="section">
-  <div class="hero fdc jcc aic full-height rel">
-    {% if settings.background_image %}
-      <img class="abs fill top x y" src="{{ img_url }}">
-    {% endif %}
-    <div class="content ac tc-white f fdc jcc aic z1">
-      <h1 class="h1">{{ settings.heading }}</h1>
+  <div class="hero fdc jcc aic full-height rel lazyload" data-bgset="{% include 'responsive-bg-image', image: settings.background_image %}">
+    <div class="content ac tc-white z1">
+      <h2 class="h1">{{ settings.heading }}</h2>
       {% if settings.show_button %}
-        <a class="button-white" href="{{ settings.button_url}}">{{ settings.button_text}}</a>
+        <a class="button-white button--large" href="{{ settings.button_url}}">{{ settings.button_text}}</a>
       {% endif %}
     </div>
   </div>

--- a/src/sections/image-with-text.liquid
+++ b/src/sections/image-with-text.liquid
@@ -1,32 +1,27 @@
 {% assign layout = section.settings.layout %}
 
 <section class="image-with-text full-height jcb fdc-m {% if layout == 'left' %} fdr {% elsif layout == 'right' %} fdr-rev {% endif %}">
-  <div class="image-with-text__image half-width {% if layout == 'left' %} mr-d {% elsif layout == 'right' %} ml-d {% endif %}">
-    {% if section.settings.image != blank %}
-      <img src="{{ section.settings.image | img_url: 'master' }}"/>
-      {% comment %} {% include 'responsive-image' with
-        image: section.settings.image,
-        max_width: 720,
-        max_height: 828,
-      %} {% endcomment %}
-    {% else %}
-      {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
-    {% endif %}
+  <div class="image-with-text__image half-width">
+      {% if section.settings.image != blank %}
+        <img class="x y" src="{{ section.settings.image | img_url: 'master' }}"/>
+      {% else %}
+        {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
+      {% endif %}
   </div>
-  <div class="image-with-text__text fdc jcb half-width">
-    {% if section.settings.heading != blank %}
-      <h2 class="h2">{{ section.settings.heading | escape }}</h2>
-    {% endif %}
-    <div class="image-with-text__p">
-      {% if section.settings.text != blank %}
-        <div>{{ section.settings.text }}</div>
+  <div class="image-with-text__text fdc jcb {% if layout == 'left' %} ml-d {% elsif layout == 'right' %} mr-d {% endif %} half-width">
+      {% if section.settings.heading != blank %}
+        <h2 class="uppercase">{{ section.settings.heading | escape }}</h2>
       {% endif %}
-      {% if section.settings.button_label != blank and section.settings.button_link != blank %}
-        <a href="{{ section.settings.button_link }}" class="button-inline">
-          {{ section.settings.button_label | escape }}
-        </a>
-      {% endif %}
-    </div>
+      <div class="image-with-text__p">
+        {% if section.settings.text != blank %}
+          <div>{{ section.settings.text }}</div>
+        {% endif %}
+        {% if section.settings.button_label != blank and section.settings.button_link != blank %}
+          <a href="{{ section.settings.button_link }}" class="button">
+            {{ section.settings.button_label | escape }}
+          </a>
+        {% endif %}
+      </div>
   </div>
 </section>
 

--- a/src/sections/image-with-text.liquid
+++ b/src/sections/image-with-text.liquid
@@ -1,9 +1,9 @@
 {% assign layout = section.settings.layout %}
 
-<section class="image-with-text full-height jcb fdc-m {% if layout == 'left' %} fdr {% elsif layout == 'right' %} fdr-rev {% endif %}">
-  <div class="image-with-text__image half-width">
+<section class="image-with-text jcb fdc-m {% if layout == 'left' %} fdr {% elsif layout == 'right' %} fdr-rev {% endif %}">
+  <div class="image-with-text__image full-height half-width">
       {% if section.settings.image != blank %}
-        <img class="x y" src="{{ section.settings.image | img_url: 'master' }}"/>
+      {% include 'responsive-image-img', image_class: "x y", image: section.settings.image %}
       {% else %}
         {{ 'image' | placeholder_svg_tag: 'placeholder-svg' }}
       {% endif %}

--- a/src/snippets/responsive-image-img.liquid
+++ b/src/snippets/responsive-image-img.liquid
@@ -1,0 +1,56 @@
+{%- comment -%}
+    It creates a style tag and it restricts an image from growing larger than its max resolution.
+
+    Dependencies:
+    - Lazysizes plugin (https://github.com/aFarkas/lazysizes) which enable responsive image with faster load time and better performance.
+    - Lazysizes Responsive Images as a Service (https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/rias) To load the correct image size with our CDN
+    - Lazysizes Bgset (https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/bgset) To use responsive images on background-image (CSS)
+
+    Accepts:
+    - max_width: {Number} Max width of the image container
+    - max_height: {Number} Max height of the image container
+    - image: {Object} Image object
+    - image_class: {String} class name of the <img />
+    - image_attributes: {String}  additional HTML attributes of the <img />
+    - wrapper_class: {String} class name of the <div> wrapper
+    - wrapper_attributes: {String} additional HTML attributes of the <div> wrapper
+
+    Usage:
+    In your liquid template file, copy the following line
+    - {% include 'responsive-image' with image: featured_image, image_class: "css-class", wrapper_class: "wrapper-css-class", max_width: 700, max_height: 800 %}
+{%- endcomment -%}
+
+{%- comment -%} Added incremental number to avoid conflict styling code when the same images are using this snippet {%- endcomment -%}
+{%- capture responsive_image_counter %}{% increment responsive_image_counter %}{% endcapture -%}
+
+
+{%- assign img_url = image | img_url: '1x1' | replace: '_1x1.', '_{width}x.' -%}
+
+{%- comment -%} Limit image widths to valid options based on image.width {%- endcomment -%}
+{%- assign image_widths = '180,360,540,720,900,1080,1296,1512,1728,1944,2160,2376,2592,2808,3024' | split: ',' -%}
+{%- capture image_widths -%}
+  {%- for width in image_widths -%}
+    {%- comment -%} Check if image width is less or equal to width {%- endcomment -%}
+    {%- assign width_num = width | plus: 0 | round -%}
+    {%- if image.width >= width_num -%}{{ width_num }},{%- endif -%}
+  {%- endfor -%}
+  {{ image.width }}
+{%- endcapture -%}
+{%- assign image_widths = image_widths | strip -%}
+
+
+<img id="Image-{{ image.id }}-{{ responsive_image_counter }}"
+  class="responsive-image__image lazyload {{ image_class }}"
+  src="{{ image | img_url: '300x' }}"
+  data-src="{{ img_url }}"
+  data-widths="[{{ image_widths }}]"
+  data-aspectratio="{{ image.aspect_ratio }}"
+  data-sizes="auto"
+  tabindex="-1"
+  alt="{{ image.alt | escape }}"
+  {{ image_attributes }}
+>
+
+<noscript>
+  <img class="{{ image_class }}" src="{{ image | img_url: '2048x2048' }}" alt="{{ image.alt | escape }}">
+</noscript>

--- a/src/snippets/responsive-image.liquid
+++ b/src/snippets/responsive-image.liquid
@@ -51,7 +51,8 @@
       When you change the window screen width, we want to make sure that the container's size is proportionally calculated.
       Note regarding padding percentage: The percentage is calculated with respect to the width of the generated box's containing block (source: http://www.w3.org/TR/2011/REC-CSS2-20110607/box.html#padding-properties)
     {%- endcomment -%}
-    padding-top:{{ max_height_image | divided_by: max_width_image | times: 100}}%;
+    content: '';
+    padding-top:{{ image.aspect_ratio | times: 100 }}%;
   }
 </style>
 

--- a/src/styles/global/_layout.scss
+++ b/src/styles/global/_layout.scss
@@ -2,9 +2,6 @@ html,
 body {
   margin: 0;
   padding: 0;
-  width: 100%;
-  height: 100%;
-  overflow: scroll;
   font-family: 'Favorit Mono', monospace;
 
   * {
@@ -46,18 +43,38 @@ a {
 
 .body-wrapper {
   max-width: 1440px;
-  margin: 0 auto;
-  padding: 0 $padding-desktop;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: $padding-desktop;
+  padding-right: $padding-desktop;
 
   @include media-query($small) {
     padding: 0 $padding-mobile;
   }
 }
 
+.index-section {
+  padding-top: $padding-mobile;
+  margin-top: 4rem;
+
+  &:first-child {
+    margin-top: 0;
+  }
+
+
+  @include media-query($medium-up) {
+    padding-top: $padding-desktop;
+    margin-top: 7.5rem;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+}
+
 main {
-  section,
-  .section {
-    padding: $padding-desktop 0;
+  @include media-query($medium-up) {
+    padding-bottom: 6rem;
   }
 }
 
@@ -69,8 +86,8 @@ main {
   border: 1px solid $black;
   color: $black;
   text-align: center;
-  padding: 0 3em;
-  line-height: 3em;
+  padding: 0 2.4em;
+  line-height: 2.4em;
   margin-top: 1.5em;
 
   &--large {

--- a/src/styles/global/_layout.scss
+++ b/src/styles/global/_layout.scss
@@ -4,13 +4,35 @@ body {
   padding: 0;
   width: 100%;
   height: 100%;
+  overflow: scroll;
   font-family: 'Favorit Mono', monospace;
+
+  * {
+    box-sizing: border-box;
+  }
+}
+
+
+p,
+h1,
+h2,
+h3,
+h4,
+h5 {
+  margin: 0;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.placeholder-svg {
+  background-color: #aaa;
 }
 
 img,
 svg,
 figure {
   display: block;
+  max-width: 100%;
 }
 
 a {
@@ -23,7 +45,7 @@ a {
 }
 
 .body-wrapper {
-  max-width: 1294px;
+  max-width: 1440px;
   margin: 0 auto;
   padding: 0 $padding-desktop;
 
@@ -32,30 +54,38 @@ a {
   }
 }
 
-section,
-.section {
-  padding: $padding-desktop 0;
+main {
+  section,
+  .section {
+    padding: $padding-desktop 0;
+  }
 }
 
 .button {
+  @include uppercase;
   @include reset-input;
-  display: block;
-  width: 100%;
+  background-color: transparent;
+  appearance: button;
   border: 1px solid $black;
   color: $black;
-  text-transform: uppercase;
   text-align: center;
-  padding: calc(1rem / 2);
-  margin-top: 24px;
+  padding: 0 3em;
+  line-height: 3em;
+  margin-top: 1.5em;
+
+  &--large {
+    @include media-query($medium-up) {
+      font-size: 2.25rem;
+      margin-top: 2em;
+      padding: 0 2em;
+      line-height: 2em;
+      border-width: 2px;
+    }
+  }
 }
 
 .button-white {
   @extend .button;
   color: $white;
-  border: 1px solid $white;
-}
-
-.button-inline {
-  @extend .button;
-  width: fit-content;
+  border-color: $white;
 }

--- a/src/styles/global/_typography.scss
+++ b/src/styles/global/_typography.scss
@@ -1,5 +1,13 @@
 /*============= Reset ================*/
 
+body {
+  line-height: 1.5;
+
+  @include media-query($small) {
+    font-size: 87.5%; // 14px
+  }
+}
+
 p {
   margin-block-start: 0;
   margin-block-end: 0;
@@ -17,23 +25,30 @@ p {
   color: $black;
 }
 
+.uppercase {
+  @include uppercase;
+}
 
 /*============= Elements ================*/
 
-.h1, .h2, .h3, .h4 {
-  font-weight: 400;
-  text-transform: uppercase;
+.h1,
+.h2,
+.h3,
+.h4,
+.h5 {
+  @include uppercase;
   line-height: 1.5;
+  font-weight: 400;
 }
 
 .h1 {
-  font-size: 48px;
+  font-size: 3rem;
   @include media-query($small) {
-    font-size: 24px;
+    font-size: 1.5rem;
   }
 }
 
 .h2 {
   font-size: 1rem;
-  margin-bottom: 24px;
+  margin-bottom: 1.5rem;
 }

--- a/src/styles/modules/header.scss
+++ b/src/styles/modules/header.scss
@@ -1,13 +1,20 @@
-$header-desktop-spacing: 64px;
+$header-desktop-spacing: 4rem;
 
-.header {
+.header-wrapper {
   position: sticky;
   top: 0;
-  text-transform: uppercase;
+  background-color: $white;
+}
+
+.header {
+  height: $header-height-desktop;
   border-bottom: 1px solid $black;
-  // display: grid;
-  // grid-template-columns: 1fr auto 1fr;
-  // grid-template-rows: auto;
+
+  &__inner {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    grid-template-rows: auto;
+  }
 
   h1 {
     margin: 0;
@@ -34,6 +41,24 @@ $header-desktop-spacing: 64px;
     }
   }
 
+  @include media-query($medium) {
+
+
+    &__left {
+      li:not(:first-child) {
+        margin-left: $header-desktop-spacing / 2;
+      }
+    }
+
+    &__right {
+      justify-content: flex-end;
+
+      li:not(:last-child) {
+        margin-right: $header-desktop-spacing / 2;
+      }
+    }
+  }
+
   ul {
     display: flex;
     list-style: none;
@@ -48,9 +73,5 @@ $header-desktop-spacing: 64px;
 
   li {
     white-space: nowrap;
-  }
-
-  @include media-query($medium-up) {
-    padding: 20px 0;
   }
 }

--- a/src/styles/modules/header.scss
+++ b/src/styles/modules/header.scss
@@ -7,10 +7,12 @@ $header-desktop-spacing: 4rem;
 }
 
 .header {
+  padding-top: 2px;
   height: $header-height-desktop;
   border-bottom: 1px solid $black;
 
   &__inner {
+    overflow: hidden;
     display: grid;
     grid-template-columns: 1fr auto 1fr;
     grid-template-rows: auto;

--- a/src/styles/modules/hero.scss
+++ b/src/styles/modules/hero.scss
@@ -2,15 +2,10 @@
   background-color: $gray;
   background-size: cover;
   @include media-query($small) {
-    padding: 16px;
+    padding: 1rem;
   }
 }
 
 .hero .content {
   max-width: 500px;
-}
-
-.hero .button {
-  width: 72px;
-  margin-top: 32px;
 }

--- a/src/styles/modules/hero.scss
+++ b/src/styles/modules/hero.scss
@@ -2,10 +2,13 @@
   background-color: $gray;
   background-size: cover;
   @include media-query($small) {
-    padding: 1rem;
+    padding: 3rem;
   }
 }
 
 .hero .content {
   max-width: 500px;
+  @include media-query($small) {
+    max-width: 320px;
+  }
 }

--- a/src/styles/modules/image-text.scss
+++ b/src/styles/modules/image-text.scss
@@ -6,6 +6,7 @@
   }
 
   svg {
+    width: 100%;
     height: 100%;
   }
 }
@@ -13,15 +14,19 @@
 .image-with-text__text {
   @include media-query($medium-up) {
     font-size: 1.25rem;
-  }
+    padding-bottom: .5em;
 
+    .button {
+      margin-bottom: .5em;
+    }
+  }
   @include media-query($large-up) {
     &.ml-d {
-      padding-left: 9%;
+      padding-left: 8%;
     }
 
     &.mr-d {
-      padding-right: 9%;
+      padding-right: 8%;
     }
   }
 

--- a/src/styles/modules/image-text.scss
+++ b/src/styles/modules/image-text.scss
@@ -1,27 +1,33 @@
-.image-with-text {
-  @include media-query($small) {
-    height: fit-content;
+.image-with-text__image {
+  img {
+    width: 100%;
+    max-height: 100%;
+    object-fit: cover;
+  }
+
+  svg {
+    height: 100%;
   }
 }
 
-.image-with-text__image {
-  background-color: $gray;
-  max-height: 100%;
-  @include media-query($small) {
-    height: 240px;
-  }
-
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-}t
-
 .image-with-text__text {
-  max-width: 512px;
+  @include media-query($medium-up) {
+    font-size: 1.25rem;
+  }
+
+  @include media-query($large-up) {
+    &.ml-d {
+      padding-left: 9%;
+    }
+
+    &.mr-d {
+      padding-right: 9%;
+    }
+  }
 
   @include media-query($small) {
+    font-size: 1rem/.875; // 16px;
     padding-top: $padding-desktop;
   }
+
 }

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -3,14 +3,20 @@
 // *************************************
 // Styles
 @import '~normalize.css';
-@import '~svbstrate';
+@import '~svbstrate/src/lib/align.css';
+@import '~svbstrate/src/lib/display.css';
+@import '~svbstrate/src/lib/flexbox.css';
+@import '~svbstrate/src/lib/forms.css';
+@import '~svbstrate/src/lib/lists.css';
+@import '~svbstrate/src/lib/positioning.css';
+@import '~svbstrate/src/lib/spacing.css';
+@import '~svbstrate/src/lib/z-index.css';
 
 // *************************************
 // ***** Util
 // *************************************
 @import './util/variables';
 @import './util/mixins';
-@import './util/responsive';
 @import './util/helpers';
 
 // *************************************
@@ -24,7 +30,7 @@
 // *************************************
 @import './modules/header';
 @import './modules/hero';
-@import './modules/image-text.scss';
+@import './modules/image-text';
 
 // *************************************
 // ***** Components

--- a/src/styles/util/_helpers.scss
+++ b/src/styles/util/_helpers.scss
@@ -1,25 +1,52 @@
+@import './responsive';
+
 /*============= Responsive Display ================*/
 
 @include responsive-display-helper;
 @include responsive-text-align-helper;
-@include grid-span-generator;
 
 /*================ Build Responsive Grid Classes ================*/
-@each $breakpoint in $breakpoints {
+@each $breakpoint in $breakpoints-has-widths {
+  .test-class {
+    color: $breakpoint;
+  }
   @include media-query($breakpoint) {
     @include responsive-display-helper('#{$breakpoint}--');
     @include responsive-text-align-helper('#{$breakpoint}--');
-    @include grid-span-generator('#{$breakpoint}--');
   }
 }
 
 /*============= Grid Layout ================*/
-.display-grid {
-  display: grid;
-  grid-template-columns: repeat(12, 1fr);
+@include media-query($medium-up) {
+  .display-grid {
+    display: grid;
+    grid-auto-flow: dense;
+    grid-gap: $padding-desktop;
+    grid-template-columns: repeat(12, 1fr);
 
-  > .display-grid__item {
-    grid-column: span 12;
+    > .display-grid__item {
+      grid-column: span 12;
+      &.span-1 { grid-column: span 1 / span 1; }
+      &.span-2 { grid-column: span 2 / span 2; }
+      &.span-3 { grid-column: span 3 / span 3; }
+      &.span-4 { grid-column: span 4 / span 4; }
+      &.span-5 { grid-column: span 5 / span 5; }
+      &.span-6 { grid-column: span 6 / span 6; }
+      &.span-7 { grid-column: span 7 / span 7; }
+      &.span-8 { grid-column: span 8 / span 8; }
+      &.span-9 { grid-column: span 9 / span 9; }
+      &.span-10 { grid-column: span 10 / span 10; }
+      &.span-11 { grid-column: span 11 / span 11; }
+      &.span-12 { grid-column: span 12 / span 12; }
+
+      &.grid-start {
+        grid-column-start: 1;
+      }
+
+      &.grid-end {
+        grid-column-end: 13;
+      }
+    }
   }
 }
 
@@ -57,13 +84,9 @@
 
 .full-height {
   height: 100vh;
-
-  @include media-query($medium) {
-    height: 50vh;
-  }
-
+  max-height: calc(100vh - #{$header-height-desktop} - #{2 * $padding-desktop});
   @include media-query($small) {
-    height: 378px;
+    max-height: calc(100vh - #{$header-height-mobile} - #{2 * $padding-mobile});
   }
 }
 

--- a/src/styles/util/_mixins.scss
+++ b/src/styles/util/_mixins.scss
@@ -48,7 +48,10 @@
   }
 }
 
-
+@mixin uppercase {
+  text-transform: uppercase;
+  letter-spacing: .022em;
+}
 // Faux underline
 @mixin faux-strikethrough {
   position: relative;

--- a/src/styles/util/_responsive.scss
+++ b/src/styles/util/_responsive.scss
@@ -14,37 +14,17 @@
 /*================ Responsive Text Alignment Helper ================*/
 @mixin responsive-text-align-helper($breakpoint: '') {
   // sass-lint:disable no-important
-  .#{$breakpoint}text-left {
+  .#{$breakpoint}tl {
     text-align: left !important;
   }
 
-  .#{$breakpoint}text-right {
+  .#{$breakpoint}tr {
     text-align: right !important;
   }
 
-  .#{$breakpoint}text-center {
+  .#{$breakpoint}tc {
     text-align: center !important;
   }
 }
 
-/*=============== Responsive Grid Item Widths =================*/
-
-@mixin grid-span-generator($breakpoint: '') {
-  .display-grid {
-    > .display-grid__item {
-      &.#{$breakpoint}span-1 { grid-column: span 1; }
-      &.#{$breakpoint}span-2 { grid-column: span 2; }
-      &.#{$breakpoint}span-3 { grid-column: span 3; }
-      &.#{$breakpoint}span-4 { grid-column: span 4; }
-      &.#{$breakpoint}span-5 { grid-column: span 5; }
-      &.#{$breakpoint}span-6 { grid-column: span 6; }
-      &.#{$breakpoint}span-7 { grid-column: span 7; }
-      &.#{$breakpoint}span-8 { grid-column: span 8; }
-      &.#{$breakpoint}span-9 { grid-column: span 9; }
-      &.#{$breakpoint}span-10 { grid-column: span 10; }
-      &.#{$breakpoint}span-11 { grid-column: span 11; }
-      &.#{$breakpoint}span-12 { grid-column: span 12; }
-    }
-  }
-}
 

--- a/src/styles/util/_variables.scss
+++ b/src/styles/util/_variables.scss
@@ -2,6 +2,10 @@
 $padding-desktop: 36px;
 $padding-mobile: 16px;
 
+// Header
+$header-height-desktop: 70px;
+$header-height-mobile: 42px;
+
 // Colors
 $black: #000;
 $white: #fff;
@@ -38,3 +42,6 @@ $breakpoints: (
   $large-up '(min-width: #{$grid-large})',
   $widescreen '(min-width: #{$grid-widescreen})'
 );
+
+$breakpoints-has-widths: ($small, $medium-up, $large-up);
+


### PR DESCRIPTION
@lilyfielding this also includes the changes from my other PR (since i wanted to use the new build script)

plus:
- adjusts some type sizes on homepage, mobile
- adjusts vertical spacing between homepage elements
- make image w/text gutter scale as a percentage on large screens
- switch header back to grid
- increase max content width
- different responsive-images snippet that doesn't try to mess with aspect ratio
- adjust full-width height
- sticky header fix (was sticking wrong element)
- remove header & body 100% because this messed up scrolling and sticky
- fiddled around with grid styling with the intention of using it on the image/text module but ended up not using this anywhere